### PR TITLE
Adds MultiTermAwareComponent to support wildcard searches

### DIFF
--- a/src/edu/stanford/lucene/analysis/CJKFoldingFilterFactory.java
+++ b/src/edu/stanford/lucene/analysis/CJKFoldingFilterFactory.java
@@ -6,13 +6,15 @@ import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
+import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
+import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 
 /**
  * Factory for CJKFoldingFilter
  * @author Naomi Dushay
  *
  */
-public class CJKFoldingFilterFactory extends TokenFilterFactory
+public class CJKFoldingFilterFactory extends TokenFilterFactory implements MultiTermAwareComponent
 {
 	public CJKFoldingFilterFactory(Map<String, String> map)
 	{
@@ -26,5 +28,10 @@ public class CJKFoldingFilterFactory extends TokenFilterFactory
 	public TokenStream create(TokenStream input)
 	{
 		return new CJKFoldingFilter(input);
+	}
+
+	@Override
+	public AbstractAnalysisFactory getMultiTermComponent() {
+		return this;
 	}
 }


### PR DESCRIPTION
@ndushay @jkeck This PR makes the CJK folding filter [multi term aware](https://lucene.apache.org/solr/guide/6_6/analyzers.html). This allows fields that use the folding filter to support wildcard searching.
Currently characters that are mapped with the folding filter are unretrievable with wildcard searches:
[Without wildcard](https://searchworks.stanford.edu/catalog?utf8=%E2%9C%93&f%5Blanguage%5D%5B%5D=Chinese&search_field=search&q=%E6%B1%89%E8%AF%AD%E5%8F%B2%E8%A7%86%E8%A7%92)
[With wildcard](https://searchworks.stanford.edu/catalog?utf8=%E2%9C%93&f%5Blanguage%5D%5B%5D=Chinese&search_field=search&q=%E6%B1%89%E8%AF%AD%E5%8F%B2%E8%A7%86%E8%A7%92*)
