### PR TITLE
Implement the normalize method

### DIFF
--- a/src/main/java/edu/stanford/lucene/analysis/CJKFoldingFilterFactory.java
+++ b/src/main/java/edu/stanford/lucene/analysis/CJKFoldingFilterFactory.java
@@ -27,4 +27,9 @@ public class CJKFoldingFilterFactory extends TokenFilterFactory
 	{
 		return new CJKFoldingFilter(input);
 	}
+
+	@Override
+	public TokenStream normalize(TokenStream input) {
+		return new CJKFoldingFilter(input);
+	}
 }


### PR DESCRIPTION
The MultiTermAwareComponenent interface was removed and replaced with the normalize method in [LUCENE-8497](https://issues.apache.org/jira/browse/LUCENE-8497) This allows the filter to run when the query term includes wildcards.